### PR TITLE
Update mediapool.php

### DIFF
--- a/redaxo/src/addons/mediapool/lib/mediapool.php
+++ b/redaxo/src/addons/mediapool/lib/mediapool.php
@@ -122,7 +122,10 @@ final class rex_mediapool
         foreach ($blockedExtensions as $blockedExtension) {
             // $blockedExtensions extensions are not allowed within filenames, to prevent double extension vulnerabilities:
             // -> some webspaces execute files named file.php.txt as php
-            if (str_contains($filename, '.' . $blockedExtension)) {
+            if ($fileExt !== '' &&
+                str_ends_with($filename, '.' . $blockedExtension) && // Prüfe ob der String mit der verbotenen Endung endet
+                !str_ends_with($filename, '.' .  $blockedExtension . '.' . $fileExt) //prüfe ob es keine doppelte Endung der Form *.php.ext gibt
+            )
                 return false;
             }
         }


### PR DESCRIPTION
Die vorhergehende Version hat zB auch Dateien mit der Erweiterung .json bei verbotener Erweiterung .js blockiert.